### PR TITLE
models/coneslayer_416x416/model.yml add Thumbnail GIF and fix links

### DIFF
--- a/models/coneslayer_416x416/model.yml
+++ b/models/coneslayer_416x416/model.yml
@@ -15,8 +15,8 @@ framework: dldt
 license: https://github.com/luxonis/depthai-model-zoo/tree/main/models/coneslayer_416x416
 meta:
   FPS:
-    mean: /
-    std: /
+    mean: 30.0
+    std: 0.01
   backbone: E-ELAN
   downloads:
   - name: coneslayer_416x416.xml
@@ -31,11 +31,11 @@ meta:
     type: image
   license:
     name: GNU GPL-3
-    url: https://github.com/WongKinYiu/yolov7/blob/main/LICENSE.md
+    url: https://raw.githubusercontent.com/mkrupczak3/Coneslayer/main/LICENSE
   source:
   - name: GitHub
-    url: https://github.com/WongKinYiu/yolov7
-  thumbnail: null
+    url: https://github.com/mkrupczak3/Coneslayer
+  thumbnail: https://github.com/mkrupczak3/Coneslayer/blob/main/assets/trackvid_inference_highlight.gif
   uses_depth: false
-  verbose_name: Coneslayer YoloV7 Tiny Variant
+  verbose_name: Coneslayer YoloV7 Tiny
 task_type: detection

--- a/models/coneslayer_416x416/model.yml
+++ b/models/coneslayer_416x416/model.yml
@@ -35,7 +35,7 @@ meta:
   source:
   - name: GitHub
     url: https://github.com/mkrupczak3/Coneslayer
-  thumbnail: https://github.com/mkrupczak3/Coneslayer/blob/main/assets/trackvid_inference_highlight.gif
+  thumbnail: https://github.com/mkrupczak3/Coneslayer/raw/main/assets/trackvid_inference_highlight.gif
   uses_depth: false
   verbose_name: Coneslayer YoloV7 Tiny
 task_type: detection


### PR DESCRIPTION
I took a look at [zoo.luxonis.com](https://zoo.luxonis.com/) today and realized I made some formatting mistakes for the Coneslayer listing (merged in #19)

Previously, the `source` link went to [github.com/WongKinYiu/yolov7](https://github.com/WongKinYiu/yolov7/) when it should point to [github.com/mkrupczak3/Coneslayer](https://github.com/mkrupczak3/Coneslayer)

I also updated `FPS` `mean` to **30.0** and `std` to **0.01**, changed `verbose_name` to "Coneslayer YoloV7 Tiny", and added the following thumbnail GIF (3.2Mb):

[https://github.com/mkrupczak3/Coneslayer/raw/main/assets/trackvid_inference_highlight.gif](https://github.com/mkrupczak3/Coneslayer/raw/main/assets/trackvid_inference_highlight.gif)
<img width="320" alt="Animated GIF of Coneslayer object detections from racetrack footage" src="https://github.com/mkrupczak3/Coneslayer/raw/main/assets/trackvid_inference_highlight.gif">